### PR TITLE
RavenDB-24201: add ansible-core 2.19 to CI test matrix

### DIFF
--- a/.github/workflows/tests_role_ravendb_node.yml
+++ b/.github/workflows/tests_role_ravendb_node.yml
@@ -18,13 +18,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install rsync
-        run: apt-get update && apt-get install -y rsync
-
       - name: Fix collection path for ansible-test # should be removed once we restructure
         run: |
           mkdir -p ansible_collections/ravendb/ravendb
-          rsync -av --exclude ansible_collections ./ ansible_collections/ravendb/ravendb
+          tar --exclude=ansible_collections -cf - . | tar -C ansible_collections/ravendb/ravendb -xf -
           cd ansible_collections/ravendb/ravendb
 
       - name: Install dependencies


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-24201/Add-ravendb-community-collection-in-Ansible