### PR TITLE
RavenDB-25059: restructure self-signed setup

### DIFF
--- a/playbooks/setup_ravendb_secured_self_signed.yml
+++ b/playbooks/setup_ravendb_secured_self_signed.yml
@@ -7,21 +7,30 @@
 #   - Installs OS prerequisites (apt/yum)
 #   - Detects distro/arch and downloads RavenDB (Ubuntu: DEB; others: tarball)
 #   - Creates ravendb user/group and required directories
+#   - Requires explicit PublicServerUrl and PublicServerUrl.Tcp per node.
+#     These must be provided in the inventory (or host_vars) using:
+#         ravendb_self_signed_public_server_url
+#         ravendb_self_signed_public_server_url_tcp
+#     The role does not construct hostnames automatically. Any valid domain and naming scheme is supported.
 #   - Copies your provided server PFX + CA cert/key to the host
+#   - Installs CA certificate into system trust store
 #   - extracts cert/key, fixes permissions, installs CA into system trust
 #   - Installs license file
 #   - Installs/updates binaries, writes systemd unit, sets CAP_NET_BIND_SERVICE
 #   - Starts/enables the ravendb systemd service
 #
+# Required Inputs:
+# Files can be given as full paths or placed under the role's files/ directory and referenced by name.
+#   - node_tag (per host, defined in inventory)
+#   - ravendb_domain (base domain for public URLs)
+#   - ravendb_certificate_file        -> server PFX
+#   - ravendb_ca_certificate_file     -> CA public certificate (crt)
+#   - ravendb_ca_key_file             -> CA private key
+#
 # Notes:
-#   - Provide the path to the ZIP via 'ravendb_setup_package'
-#       * ravendb_certificate_file   -> server PFX (e.g., server.pfx)
-#       * ravendb_ca_certificate_file -> CA PEM (public)
-#       * ravendb_ca_key_file         -> CA private key (only if your flow needs it on node)
-#   - The role **does not generate** certificates; it only installs what you supply.
-#   - This playbook does not register client certs back on the controller for you; handle
-#     client certificate distribution/registration separately.
-#   - This is for self-signed-secured installs only. for LE-secured setup please refer to:  playbooks/setup_ravendb_secured.yml
+#   - The role does NOT generate server certificates; it installs what you supply.
+#   - This playbook is for self-signed-secured installs only.
+#   - For Let's Encrypt-secured setup refer to: playbooks/setup_ravendb_secured.yml
 #################################################################################################
 
 - name: Install/Upgrade RavenDB (Self-signed - secured)
@@ -31,11 +40,11 @@
     - role: ravendb.ravendb.ravendb_node
       vars:
         ravendb_state: present
+        ravendb_version_minor: 6.2
+        ravendb_version: latest
         ravendb_secured_self_signed_enabled: true
         ravendb_certificate_file: "/home/user/server.pfx"
-        ravendb_certificate_password: "raven"     # just for demo puposes - use Ansible vault
-        ravendb_ca_certificate_file: "/home/user/ca_cert.pem"
-        ravendb_ca_key_file: "/home/user/ca_key.pem"
+        ravendb_ca_certificate_file: "/home/user/ca.crt"
+        ravendb_ca_key_file: "/home/user/ca.key"
         ravendb_license_file: "/home/user/license.json"
-        ravendb_hostname: "{{ ansible_host }}"
         ravendb_settings_preset: default

--- a/roles/ravendb_node/meta/argument_specs.yml
+++ b/roles/ravendb_node/meta/argument_specs.yml
@@ -85,11 +85,11 @@ argument_specs:
       ravendb_ca_certificate_file:
         type: path
         required: false
-        default: "ca_cert.pem"
+        default: "ca.crt"
         description: "Path to the CA certificate file."
 
       ravendb_ca_key_file:
         type: path
         required: false
-        default: "ca_key.pem"
+        default: "ca.key"
         description: "Path to the CA key file."

--- a/roles/ravendb_node/molecule/secured_self_signed/converge.yml
+++ b/roles/ravendb_node/molecule/secured_self_signed/converge.yml
@@ -17,6 +17,5 @@
         ravendb_secured_self_signed_enabled: true
         ravendb_license_file: "license.json"
         ravendb_certificate_file: "server.pfx"
-        ravendb_certificate_password: "raven"
-        ravendb_ca_certificate_file: "ca_cert.pem"
-        ravendb_ca_key_file: "ca_key.pem"
+        ravendb_ca_certificate_file: "ca.crt"
+        ravendb_ca_key_file: "ca.key"

--- a/roles/ravendb_node/molecule/secured_self_signed/molecule.yml
+++ b/roles/ravendb_node/molecule/secured_self_signed/molecule.yml
@@ -2,27 +2,26 @@ dependency:
   name: galaxy
 driver:
   name: docker
-  port_bindings:
-    '8080': 80
-    '38888': 38888
-    '44443': 443
+
 platforms:
-  - name: ubuntu-bionic
-    image: 'jrei/systemd-ubuntu:22.04'
+  - name: a.ravendb-self-signed
+    image: 'docker.io/geerlingguy/docker-ubuntu2204-ansible:latest'
     privileged: true
+    command: /usr/sbin/init
     volumes:
       - '/sys/fs/cgroup:/sys/fs/cgroup:rw'
     tmpfs:
       - /run
       - /tmp
-    command: /lib/systemd/systemd
-lint: |
-  set -e
-  yamllint .
-  ansible-lint
+    cgroupns_mode: host
+
 provisioner:
   name: ansible
   log: true
+  inventory:
+    host_vars:
+      a.ravendb-self-signed:
+        node_tag: "A"
 scenario:
   name: secured_self_signed
   test_sequence:

--- a/roles/ravendb_node/molecule/secured_self_signed/verify.yml
+++ b/roles/ravendb_node/molecule/secured_self_signed/verify.yml
@@ -4,38 +4,23 @@
   gather_facts: false
   tasks:
 
-    - name: Load settings.json
-      become: yes
-      include_vars:
-        file: "/etc/ravendb/settings.json"
-        name: settings
-
-    - name: Assert that settings override was applied
-      ansible.builtin.assert:
-        that:
-          - settings['Logs.Mode'] == "Information"
-
-    - name: Assert it's unsecured
-      ansible.builtin.assert:
-        that:
-          - settings['ServerUrl'] is not regex('^https:')
-
     - name: Get service status
       become: true
-      systemd:
+      ansible.builtin.systemd:
         name: ravendb.service
         state: started
       register: service_status
 
     - name: Assert service state
       ansible.builtin.assert:
-        that: service_status.status | json_query('ActiveState') == 'active'
+        that:
+          - service_status.status['ActiveState'] == 'active'
 
-    - name: Verify RavenDB Studio HTML is inaccessible without cert being provided
+    - name: Verify RavenDB is inaccessible without cert being provided
       ansible.builtin.uri:
-        url: https://localhost:443/studio/index.html
+        url: https://localhost:443/databases
         validate_certs: no
-        status_code: 403 
+        status_code: 403
       register: curl_output
 
     - name: Assert 'InvalidAuth' message in response
@@ -43,22 +28,143 @@
         that:
           - curl_output.json.Type == "InvalidAuth"
 
-    - name: Install curl
+    - name: Install pacakges
       become: true
       ansible.builtin.package:
-        name: curl
+        name: 
+          - curl
+          - openssl
         state: present
 
+    - name: Extract server certificate
+      become: true
+      command: >
+        openssl pkcs12 -in /etc/ravendb/security/server.pfx
+        -clcerts -nokeys -out /etc/ravendb/security/server.pem -legacy -passin pass:
+      args:
+        creates: /etc/ravendb/security/server.pem
+    
+    - name: Extract server private key
+      become: true
+      command: >
+        openssl pkcs12 -in /etc/ravendb/security/server.pfx
+        -nocerts -nodes -out /etc/ravendb/security/server.key -legacy -passin pass:
+      args:
+        creates: /etc/ravendb/security/server.key 
+
+    - name: Set correct permissions for all certificates and keys
+      become: true
+      file:
+        path: "{{ item }}"
+        mode: "0600"
+        owner: root
+        group: root
+      loop:
+        - /etc/ravendb/security/server.pem
+        - /etc/ravendb/security/server.key
+
+    - name: Create client OpenSSL config (self-signed)
+      become: true
+      ansible.builtin.copy:
+        dest: /etc/ravendb/security/client_openssl.cnf
+        owner: ravendb
+        group: ravendb
+        mode: "0640"
+        content: |
+          [ req ]
+          default_bits       = 4096
+          prompt             = no
+          default_md         = sha256
+          distinguished_name = req_distinguished_name
+          req_extensions     = req_ext
+
+          [ req_distinguished_name ]
+          CN = admin-client
+
+          [ req_ext ]
+          keyUsage = critical, digitalSignature, keyEncipherment
+          extendedKeyUsage = clientAuth
+      tags: config,self_signed
+      
+    - name: Generate client private key
+      become: true
+      command: >
+        openssl genrsa -out /etc/ravendb/security/client.key 4096
+      args:
+        creates: /etc/ravendb/security/client.key
+
+    - name: Generate client certificate signing request
+      become: true
+      command: >
+        openssl req -new
+        -key /etc/ravendb/security/client.key
+        -out /etc/ravendb/security/client.csr
+        -config /etc/ravendb/security/client_openssl.cnf
+      args:
+        creates: /etc/ravendb/security/client.csr
+
+    - name: Sign client certificate with CA
+      become: true
+      command: >
+        openssl x509 -req
+        -in /etc/ravendb/security/client.csr
+        -CA /etc/ravendb/security/ca.crt
+        -CAkey /etc/ravendb/security/ca.key
+        -CAcreateserial
+        -out /etc/ravendb/security/client.crt
+        -days 3650
+        -sha256
+        -extfile /etc/ravendb/security/client_openssl.cnf
+        -extensions req_ext
+      args:
+        creates: /etc/ravendb/security/client.crt
+
+    - name: Combine client key and certificate into PEM bundle
+      become: true
+      command: >
+        bash -c "cat /etc/ravendb/security/client.key /etc/ravendb/security/client.crt > /etc/ravendb/security/client.pem"
+      args:
+        creates: /etc/ravendb/security/client.pem
+
+    - name: Export client certificate to PKCS#12 (PFX)
+      become: true
+      command: >
+        openssl pkcs12 -export
+        -out /etc/ravendb/security/client.pfx
+        -inkey /etc/ravendb/security/client.key
+        -in /etc/ravendb/security/client.crt
+        -certfile /etc/ravendb/security/ca.crt
+        -passout pass:
+      args:
+        creates: /etc/ravendb/security/client.pfx
+
+    - name: Register admin client certificate in server
+      become: true
+      shell: >
+        curl -X PUT "https://localhost:443/admin/certificates"
+        -H "Content-Type: application/json"
+        --cert /etc/ravendb/security/selfsigned/server.pem
+        --key /etc/ravendb/security/selfsigned/server.key
+        -d '{
+          "Name": "AdminClientCert",
+          "Certificate": "'"$(cat /etc/ravendb/security/client.pfx | base64 -w 0)"'",
+          "SecurityClearance": "ClusterAdmin"
+        }'
+      register: cert_register
+      changed_when: '"error" not in cert_register.stdout'
+      failed_when: '"InvalidAuth" in cert_register.stdout'
+
+    # intended only for local testing , therefore my personal domain is used with redirect
+    # to use your cert with this test please update the SAN defined in your crt on the cmd below
     - name: Verify RavenDB Studio access with client certificate
       become: true
       ansible.builtin.command:
-        cmd: "curl -k --cert-type PEM --cert /etc/ravendb/security/raven_cert.pem --key /etc/ravendb/security/raven_key.pem -o /dev/null -s -w '%{http_code}' https://localhost:443/studio/index.html"
+        cmd: >
+          curl --resolve a.thegoldenplatypusselfsigned.development.run:443:127.0.0.1
+          --cert /etc/ravendb/security/client.pfx:
+          --cert-type P12
+          --cacert /etc/ravendb/security/ca.crt
+          -s -o /dev/null -w '%{http_code}'
+          https://a.thegoldenplatypusselfsigned.development.run:443
       register: curl_output
-      failed_when: curl_output.stdout != '200'
-
-    - name: Verify server certificate against CA certificate
-      become: true
-      ansible.builtin.shell:
-        cmd: "echo | openssl s_client -connect localhost:443 -CAfile /etc/ravendb/security/ca_certificate.pem -verify_return_error"
-      register: ca_validation_output
-      failed_when: "'Verify return code: 0 (ok)' not in ca_validation_output.stdout"
+      failed_when: curl_output.stdout != "302"

--- a/roles/ravendb_node/tasks/ravendb_secure_self_sign_setup.yml
+++ b/roles/ravendb_node/tasks/ravendb_secure_self_sign_setup.yml
@@ -1,73 +1,91 @@
+- name: Resolve certificate/key source paths
+  ansible.builtin.set_fact:
+    ravendb_server_pfx_src: >-
+      {{
+        (ravendb_certificate_file is match('^(/|~)'))
+        | ternary(ravendb_certificate_file, role_path ~ '/files/' ~ ravendb_certificate_file)
+      }}
+    ravendb_ca_cert_src: >-
+      {{
+        (ravendb_ca_certificate_file is match('^(/|~)'))
+        | ternary(ravendb_ca_certificate_file, role_path ~ '/files/' ~ ravendb_ca_certificate_file)
+      }}
+    ravendb_ca_key_src: >-
+      {{
+        (ravendb_ca_key_file is match('^(/|~)'))
+        | ternary(ravendb_ca_key_file, role_path ~ '/files/' ~ ravendb_ca_key_file)
+      }}
+  delegate_to: localhost
+
 - name: Ensure RavenDB server certificate file is present
   assert:
     that: 
       - ravendb_certificate_file is not none
       - ravendb_certificate_file | length > 0
-    fail_msg: "The RavenDB server certificate file is missing. It should be located in: roles/ravendb_node/files"
+    fail_msg: "The RavenDB server certificate file is missing. Please provide an absolute path or locate it under: roles/ravendb_node/files"
 
 - name: Check if RavenDB server certificate file exists
   stat:
-    path: "{{ role_path }}/files/{{ ravendb_certificate_file }}"
+    path: "{{ ravendb_server_pfx_src }}"
   register: server_cert_stat
   delegate_to: localhost
 
 - name: Fail if RavenDB server certificate file is missing
   fail:
-    msg: "The RavenDB server certificate file is missing in roles/ravendb_node/files"
+    msg: "The RavenDB server certificate file is missing: {{ ravendb_server_pfx_src }}"
   when: not server_cert_stat.stat.exists
 
-
-- name: Ensure RavenDB CA pem file is present
+- name: Ensure RavenDB CA cert file is present
   assert:
     that:
       - ravendb_ca_certificate_file is not none
       - ravendb_ca_certificate_file | length > 0
-    fail_msg: "The RavenDB CA pem file is missing. It should be located in: roles/ravendb_node/files"
+    fail_msg: "The RavenDB CA cert file is missing. Please provide an absolute path or locate it under: roles/ravendb_node/files"
 
-- name: Check if RavenDB CA pem file exists
+- name: Check if RavenDB CA cert file exists
   stat:
-    path: "{{ role_path }}/files/{{ ravendb_ca_certificate_file }}"
-  register: ca_pem_stat
-  delegate_to: localhost
-
-- name: Fail if RavenDB CA pem file is missing
-  fail:
-    msg: "The RavenDB CA pem file is missing in roles/ravendb_node/files"
-  when: not ca_pem_stat.stat.exists
-  
-- name: Ensure RavenDB CA certificate for system CA certificates is present
-  assert:
-    that:
-      - ravendb_ca_certificate_file is not none
-      - ravendb_ca_certificate_file | length > 0
-    fail_msg: "The RavenDB CA certificate file for system CA certificates is missing. It should be located in: roles/ravendb_node/files"  
-
-- name: Check if RavenDB CA certificate file exists
-  stat:
-    path: "{{ role_path }}/files/{{ ravendb_ca_certificate_file }}"
+    path: "{{ ravendb_ca_cert_src }}"
   register: ca_cert_stat
   delegate_to: localhost
 
-- name: Fail if RavenDB CA certificate file is missing
+- name: Fail if RavenDB CA cert file is missing
   fail:
-    msg: "The RavenDB CA certificate file is missing in roles/ravendb_node/files"
+    msg: "The RavenDB CA cert file is missing: {{ ravendb_ca_cert_src }}"
   when: not ca_cert_stat.stat.exists
   
+- name: Ensure RavenDB CA key for system CA certificates is present
+  assert:
+    that:
+      - ravendb_ca_key_file is not none
+      - ravendb_ca_key_file | length > 0
+    fail_msg: "The RavenDB CA key file is missing. Please provide an absolute path or locate it under: roles/ravendb_node/files"
+
+- name: Check if RavenDB CA key file exists
+  stat:
+    path: "{{ ravendb_ca_key_src }}"
+  register: ca_key_stat
+  delegate_to: localhost
+
+- name: Fail if RavenDB CA key file is missing
+  fail:
+    msg: "The RavenDB CA key file is missing: {{ ravendb_ca_key_src }}"
+  when: not ca_key_stat.stat.exists
+
 - block:
   - name: Copy RavenDB server certificate file
     become: true
     ansible.builtin.copy:
-      src: "{{ ravendb_certificate_file }}"
-      dest: /etc/ravendb/security/certificate.pfx
+      src: "{{ ravendb_server_pfx_src }}"
+      dest: /etc/ravendb/security/server.pfx
       owner: ravendb
       group: ravendb
       mode: '0640'
   
-  - name: Copy RavenDB CA pem file
+  - name: Copy RavenDB CA certificate file
     become: true
     ansible.builtin.copy:
-      src: "{{ ravendb_ca_certificate_file }}"
-      dest: /etc/ravendb/security/ca_certificate.pem
+      src: "{{ ravendb_ca_cert_src }}"
+      dest: /etc/ravendb/security/ca.crt
       owner: ravendb
       group: ravendb
       mode: '0640'
@@ -75,8 +93,8 @@
   - name: Copy RavenDB CA certificate to system CA certificates
     become: true
     ansible.builtin.copy:
-      src: "{{ ravendb_ca_certificate_file }}"
-      dest: /usr/local/share/ca-certificates/ravendb_ca.crt
+      src: "{{ ravendb_ca_cert_src }}"
+      dest: /usr/local/share/ca-certificates/ca.crt
       owner: root
       group: ravendb
       mode: '0644'
@@ -90,43 +108,10 @@
   - name: Copy RavenDB CA key file
     become: true
     ansible.builtin.copy:
-      src: "{{ ravendb_ca_key_file }}"
-      dest: /etc/ravendb/security/ca_key.pem
+      src: "{{ ravendb_ca_key_src }}"
+      dest: /etc/ravendb/security/ca.key
       owner: ravendb
       group: ravendb
       mode: '0640' 
 
-  - name: Extract certificate from PFX file
-    become: true
-    ansible.builtin.command:
-      cmd: "openssl pkcs12 -in /etc/ravendb/security/certificate.pfx -out /etc/ravendb/security/raven_cert.pem -clcerts -nokeys -passin pass:raven"
-    args:
-      creates: /etc/ravendb/security/raven_cert.pem    
-
-  - name: Extract private key from PFX file (raven_key.pem)
-    become: true
-    ansible.builtin.command:
-      cmd: "openssl pkcs12 -in /etc/ravendb/security/certificate.pfx -out /etc/ravendb/security/raven_key.pem -nocerts -nodes -passin pass:raven"
-    args:
-      creates: /etc/ravendb/security/raven_key.pem
-
-  - name: Combine certificate and private key into a single PEM file
-    become: true
-    ansible.builtin.shell:
-      cmd: "cat /etc/ravendb/security/raven_key.pem /etc/ravendb/security/raven_cert.pem > /etc/ravendb/security/combined_raven_cert.pem"
-    args:
-      creates: /etc/ravendb/security/combined_raven_cert.pem  
-
-  - name: Adjust extracted files permissions
-    become: true
-    ansible.builtin.file:
-      name: "{{ item }}"
-      owner: ravendb
-      group: ravendb
-      mode: u=rw
-    loop:
-      - "/etc/ravendb/security/raven_key.pem"
-      - "/etc/ravendb/security/combined_raven_cert.pem"
-      - "/etc/ravendb/security/raven_cert.pem"
-      
   tags: config,self_signed

--- a/roles/ravendb_node/templates/settings.default.json.j2
+++ b/roles/ravendb_node/templates/settings.default.json.j2
@@ -4,24 +4,39 @@
 {% set has_certificate_password = ravendb_certificate_password is defined and ravendb_certificate_password and ravendb_certificate_password != "" %}
 {% set ravendb_port = ravendb_https_port if secured else ravendb_http_port %}
 {% set http_scheme = "https" if secured else "http" %}
-{% if has_hostname %}
-{% set public_url = http_scheme ~ "://" ~ ravendb_hostname ~ ":" ~ ravendb_port %}
-{% set public_url_tcp = "tcp://" ~ ravendb_hostname ~ ":" ~ ravendb_tcp_port %}
+
+{% set has_self_signed_public_https = ravendb_self_signed_public_hostname_https is defined and ravendb_self_signed_public_hostname_https and ravendb_self_signed_public_hostname_https != "" %}
+{% set has_self_signed_public_tcp  = ravendb_self_signed_public_hostname_tcp  is defined and ravendb_self_signed_public_hostname_tcp  and ravendb_self_signed_public_hostname_tcp  != "" %}
+
+{% if ravendb_secured_self_signed_enabled | default(false)
+      and ravendb_self_signed_public_server_url is defined
+      and ravendb_self_signed_public_server_url | length > 0 %}
+    "PublicServerUrl": "{{ ravendb_self_signed_public_server_url }}",
 {% endif %}
+
+{% if ravendb_secured_self_signed_enabled | default(false)
+      and ravendb_self_signed_public_server_url_tcp is defined
+      and ravendb_self_signed_public_server_url_tcp | length > 0 %}
+    "PublicServerUrl.Tcp": "{{ ravendb_self_signed_public_server_url_tcp }}",
+{% endif %}
+
 {
-    "Setup.Mode": "{{ 'LetsEncrypt' if secured else 'None' }}",
+    "Setup.Mode": "{{ 'None' if ravendb_secured_self_signed_enabled else ('LetsEncrypt' if secured else 'None') }}",
     "ServerUrl": "{{ http_scheme }}://0.0.0.0:{{ ravendb_port }}",
     "ServerUrl.Tcp": "tcp://0.0.0.0:{{ ravendb_tcp_port }}",
 
-{% if has_hostname %}
+{% if public_url is defined %}
     "PublicServerUrl": "{{ public_url }}",
+{% endif %}
+{% if public_url_tcp is defined %}
     "PublicServerUrl.Tcp": "{{ public_url_tcp }}",
 {% endif %}
+
     "Logs.Mode": "Operations",
     "Logs.RetentionTimeInHrs": 336,
 
 {% if secured %}
-    "Security.Certificate.Path": "/etc/ravendb/security/certificate.pfx",
+    "Security.Certificate.Path": "/etc/ravendb/security/server.pfx",
     {% if has_certificate_password %}
     "Security.Certificate.Password": "{{ ravendb_certificate_password }}",
     {% endif %}


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-25059/Ansible-restructure-self-signed-setup
---

# PR: Refactor Self-Signed Secured Setup

## Overview

This PR refactors and stabilizes the **self-signed secured installation flow** of the `ravendb_node` role.

The goal was to:

- Remove implicit assumptions (domain, node_tag, hostname construction)
- Make the setup fully explicit and domain-agnostic
- Clean up certificate handling logic
- Remove unnecessary PEM extraction steps
- Improve idempotency
- Keep other setups (LetsEncrypt / unsecured) untouched

This PR does **not** introduce new features.   It hardens and clarifies the existing self-signed secured path.

NOTE: Although a full end-to-end test scenario was implemented for the self-signed secured setup (including certificate generation, installation, and service validation), it was intentionally kept for **local testing only** and not integrated into CI. 
The reason is to avoid introducing additional secrets into the repository or pipeline configuration, as well as the ongoing burden of maintaining and rotating test certificates inside CI. The scenario remains available for local validation when needed.